### PR TITLE
Enable Lean builds in CI

### DIFF
--- a/.github/workflows/lean_build.yml
+++ b/.github/workflows/lean_build.yml
@@ -1,0 +1,53 @@
+on:
+  push:
+  pull_request:
+
+jobs:
+  update_lean_xyz_branch_and_build:
+    runs-on: ubuntu-latest
+    name: Build project
+    steps:
+
+    - name: checkout project
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: update branch
+      if: github.ref == 'refs/heads/master'
+      uses: leanprover-contrib/update-versions-action@master
+
+    - name: Install elan
+      run: |
+        set -o pipefail
+        curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- --default-toolchain none -y
+        ~/.elan/bin/lean --version
+        echo "$HOME/.elan/bin" >> $GITHUB_PATH
+    - name: install Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+
+    - name: Install leanproject
+      run: |
+        python3 -m pip install --user pipx
+        python3 -m pipx ensurepath
+        source ~/.profile
+        pipx install mathlibtools
+    - name: Set up olean cache
+      uses: actions/cache@v3
+      with:
+        path: _cache
+        key: oleans
+
+    - name: Configure
+      run: |
+        leanpkg configure
+        leanproject get-mathlib-cache
+        leanproject get-cache --fallback=download-first || true
+    - name: Build
+      run: |
+        lean --json --make src | python3 _target/deps/mathlib/scripts/detect_errors.py
+    - name: Save olean cache
+      run: |
+        leanproject mk-cache

--- a/src/chapters/11_Lines_in_the_plane_and_decompositions_of_graphs.lean
+++ b/src/chapters/11_Lines_in_the_plane_and_decompositions_of_graphs.lean
@@ -18,8 +18,6 @@ Authors: Moritz Firsching
 import tactic
 import geometry.euclidean.basic
 
-open inner_product_geometry
-
 noncomputable theory
 open_locale big_operators
 open_locale classical


### PR DESCRIPTION
This is taken from https://github.com/eric-wieser/lean-graded-rings/blob/master/.github/workflows/lean_build.yml, which has a few nice features on top of the usual script (notably, not rebuilding from scratch).

To see this in action, you might need to click a button below the PR to enable builds.

Alternatively, you might need to go to the "actions" tab.